### PR TITLE
password-store: 1.7.1-r2 -> 1.7.2

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,3 +1,0 @@
-[gerrit]
-host=galileo.mailstation.de
-project=kdecherf

--- a/metadata/repository_mask.conf
+++ b/metadata/repository_mask.conf
@@ -1,0 +1,7 @@
+app-admin/password-store[<1.7.2] [[
+    author = [ Kylie McClain <somasis@exherbo.org> ]
+    date = [ 14 Jun 2018 ]
+    token = security
+    description = [ CVE-2018-12356; https://lists.zx2c4.com/pipermail/password-store/2018-June/003308.html ]
+]]
+

--- a/packages/app-admin/password-store/password-store-1.7.2.exheres-0
+++ b/packages/app-admin/password-store/password-store-1.7.2.exheres-0
@@ -7,18 +7,28 @@ PLATFORMS="~amd64"
 
 ZSH_COMPLETIONS=( 'src/completion/pass.zsh-completion _pass' )
 
-DEFAULT_SRC_INSTALL_PARAMS=( PREFIX=/usr/$(exhost --target)  MANDIR=/usr/share/man )
+DEFAULT_SRC_INSTALL_PARAMS=(
+    PREFIX=/usr/$(exhost --target)
+    MANDIR=/usr/share/man
+    WITH_BASHCOMP=$(option bash-completion yes no)
+    WITH_ZSHCOMP=$(option zsh-completion yes no)
+    BASHCOMPDIR="${BASHCOMPLETIONDIR}"
+    ZSHCOMPDIR="${ZSHCOMPLETIONDIR}"
+)
 
 src_install() {
     default
+
+    if option vim ; then
+        dodir /usr/share/vim/vimfiles
+        insinto /usr/share/vim/vimfiles
+        doins "${WORK}"/contrib/vim/*
+    fi
 
     if option dmenu ; then
         dobin "${WORK}"/contrib/dmenu/passmenu
     fi
 
     keepdir /usr/$(exhost --target)/lib/${PN}/extensions
-
-    dobashcompletion src/completion/pass.bash-completion pass
-    install-zsh-completions
 }
 

--- a/packages/app-admin/password-store/password-store.exlib
+++ b/packages/app-admin/password-store/password-store.exlib
@@ -7,7 +7,10 @@ DOWNLOADS="http://git.zx2c4.com/${PN}/snapshot/${PNV}.tar.xz"
 
 LICENCES="GPL-2"
 SLOT="0"
-MYOPTIONS="dmenu [[ description = [ Install passmenu, a dmenu-based interface to pass ] ]]"
+MYOPTIONS="
+    dmenu [[ description = [ Install passmenu, a dmenu-based interface to pass ] ]]
+    vim-syntax [[ description = [ Install redact_pass, which switches off leaky options when editing pass files ] ]]
+"
 
 DEPENDENCIES="
     run:
@@ -16,15 +19,17 @@ DEPENDENCIES="
         app-misc/tree[>=1.7.0]
         dev-scm/git
         dmenu? ( x11-misc/dmenu )
+        vim-syntax? ( app-editors/vim-runtime )
+    test:
+        app-crypt/gnupg[>=2.2]
     suggestion:
         media-libs/qrencode:* [[ description = [ Required for printing passwords as QR codes ] ]]
         x11-utils/xclip [[ description = [ Required for copying the password into the clipboard ] ]]
         dmenu? ( x11-apps/xdotool [[ description = [ Required for typing password with passmenu ] ]] )
         app-admin/pass-report [[ description = [ Adds report command whichs reports passwords' age ] ]]
         app-admin/pass-update [[ description = [ Adds update command whichs helps cycle passwords ] ]]
+        app-admin/browserpass [[ description = [ Browser extension for interacting with pass ] ]]
 "
-
-
 
 # Fails with gnupg 2.1
 RESTRICT="test"


### PR DESCRIPTION
This fixes [CVE-2018-12356](https://lists.zx2c4.com/pipermail/password-store/2018-June/003308.html), which was announced just today.

Also, removal of `.gitreview`, a relic from Gerrit.