### PR TITLE
password-store: add option for fish completion.

### DIFF
--- a/packages/app-admin/password-store/password-store-1.7.3-r1.exheres-0
+++ b/packages/app-admin/password-store/password-store-1.7.3-r1.exheres-0
@@ -12,8 +12,10 @@ src_install() {
         MANDIR=/usr/share/man \
         WITH_BASHCOMP=$(option bash-completion yes no) \
         WITH_ZSHCOMP=$(option zsh-completion yes no) \
+        WITH_FISHCOMP=$(option fish-completion yes no) \
         BASHCOMPDIR="${BASHCOMPLETIONDIR}" \
-        ZSHCOMPDIR="${ZSHCOMPLETIONDIR}"
+        ZSHCOMPDIR="${ZSHCOMPLETIONDIR}" \
+        FISHCOMPDIR="/usr/share/fish/vendor_completions.d"
 
     if option vim-syntax ; then
         dodir /usr/share/vim/vimfiles

--- a/packages/app-admin/password-store/password-store.exlib
+++ b/packages/app-admin/password-store/password-store.exlib
@@ -10,6 +10,7 @@ SLOT="0"
 MYOPTIONS="
     dmenu [[ description = [ Install passmenu, a dmenu-based interface to pass ] ]]
     vim-syntax [[ description = [ Install redact_pass, which switches off leaky options when editing pass files ] ]]
+    fish-completion
 "
 
 DEPENDENCIES="


### PR DESCRIPTION
I'm having a go at fish for the next few weeks. So I need completion :grin: 

(I may make a fish-completion exlib at some point if I decide to stick with this shell.)